### PR TITLE
SEC-1024: adding gds.eligibleapi.com ssl fingerprint required for future rotations

### DIFF
--- a/lib/http/client.js
+++ b/lib/http/client.js
@@ -16,6 +16,7 @@ var request = require('request').defaults({
 var FINGERPRINTS = [
   '79:D6:2E:8A:9D:59:AE:68:73:72:F8:E7:13:45:C7:6D:92:52:7F:AC',
   '4B:2C:68:88:ED:E7:9D:0E:E4:73:39:DC:6F:AB:5A:6D:0D:C3:CB:0E',
+  'DE:4C:DD:0A:AE:26:DF:71:29:0F:03:73:AF:18:E9:EE:7E:CF:F1:8C',
 ];
 
 function handleResponse(response, body) {

--- a/lib/http/client.js
+++ b/lib/http/client.js
@@ -14,7 +14,6 @@ var request = require('request').defaults({
 
 // Certificate fingerprints for gds.eligibleapi.com
 var FINGERPRINTS = [
-  '79:D6:2E:8A:9D:59:AE:68:73:72:F8:E7:13:45:C7:6D:92:52:7F:AC',
   '4B:2C:68:88:ED:E7:9D:0E:E4:73:39:DC:6F:AB:5A:6D:0D:C3:CB:0E',
   'DE:4C:DD:0A:AE:26:DF:71:29:0F:03:73:AF:18:E9:EE:7E:CF:F1:8C',
 ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eligible-node",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Eligible Node.js bindings https://eligible.com",
   "keywords": [
     "eligible",


### PR DESCRIPTION
|JIRA    | [SEC-1024](https://eligible.atlassian.net/browse/SEC-1024)
|:-------|:-----------------------------------------------------------

### Description
We are in the process of rotating gds.eligibleapi.com certificate. Adding new
certificate for gds.eligibleapi.com which will be used for future certificate
rotations.